### PR TITLE
Don't ask to host the cert on a webserver for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ my_validator_name/
 ```json
 {
     "ca": "my_validator_name/server_ca.crt",
-    "ca_hosted": "https://steward.mydomain.com/server_ca.crt",
     "endpoint": "https://steward.mydomain.com:5734"
 }
 ```
 
-### Explanation
-
-The `ca_hosted` and `ca` fields must point to two copies of the *same file*, one hosted at your domain, one hosted in this repo. This provides a means of ensuring that you own the domain in question.


### PR DESCRIPTION
Trying to do cert verification by complicating the steward deployment setup is unhelpful during this initial phase. We will manually follow up to verify cert information.